### PR TITLE
refactors logging

### DIFF
--- a/dnacommon/ep_logging.py
+++ b/dnacommon/ep_logging.py
@@ -2,15 +2,6 @@ import logging
 
 import sys
 
-CRITICAL = logging.CRITICAL
-FATAL = logging.FATAL
-ERROR = logging.ERROR
-WARN = logging.WARN
-WARNING = logging.WARNING
-INFO = logging.INFO
-DEBUG = logging.DEBUG
-NOTSET = logging.NOTSET
-
 _logging_nameToLevel = {
     'CRITICAL': logging.CRITICAL,
     'FATAL': logging.FATAL,
@@ -23,11 +14,8 @@ _logging_nameToLevel = {
 }
 
 
-def name_as_level(name: str):
-    if name is not None:
-        return _logging_nameToLevel.get(name.upper(), "INFO")
-    else:
-        return "INFO"
+def name_as_level(name: str) -> int:
+    return _logging_nameToLevel.get(name.upper(), logging.INFO) if name is not None else logging.INFO
 
 
 def get_logger(name, loglevel=logging.DEBUG):
@@ -37,7 +25,8 @@ def get_logger(name, loglevel=logging.DEBUG):
     if not logger.handlers:
         ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(loglevel)
-        formatter = logging.Formatter('[%(levelname)s] %(asctime)s - %(name)s - %(message)s')
+        formatter = logging.Formatter(
+            '[%(levelname)s] %(asctime)s - %(name)s - %(message)s')
         ch.setFormatter(formatter)
         logger.addHandler(ch)
     return logger

--- a/tests/test_datalake_input_event.py
+++ b/tests/test_datalake_input_event.py
@@ -1,6 +1,6 @@
 import json
 
-from datalake.input_event import DatalakeInputEvent
+from dnacommon.datalake.input_event import DatalakeInputEvent
 
 
 def test_input_event_creation():
@@ -42,4 +42,5 @@ def test_publish():
         identifiers={'id1': 'a', 'id2': 'b'},
         tags=['tag1', 'tag2']
     )
-    assert event.send('arn:aws:sns:eu-central-1:677740320946:DeadLetter')['MessageId'] is not None
+    assert event.send(
+        'arn:aws:sns:eu-central-1:677740320946:DeadLetter')['MessageId'] is not None

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,14 @@
+import pytest
+import logging
+from dnacommon.ep_logging import name_as_level
+
+
+@pytest.mark.parametrize("test_input, expected", [
+    ("deBug", logging.DEBUG),
+    ("debug", logging.DEBUG),
+    ("ERROR", logging.ERROR),
+    ("Deb", logging.INFO),
+    (None, logging.INFO)
+])
+def test_name_as_level(test_input, expected):
+    assert name_as_level(test_input) is expected


### PR DESCRIPTION
Ich habe mir mal erlaubt die ungenutzten levels zu entfernen, da consumer diese auch aus `logging` benutzen können ... reduziert bei uns die Komplexität.

Für die Methode `name_as_level` hab ich mal nen Test geschrieben, da diese nicht das gemacht hat, was sie impliziert (name&rarr;level). Außerdem hab ich mal die Typannotation (`str`&rarr;`int`) engefügt, damit dies beim nächsten Mal offensichtlicher ist. 
